### PR TITLE
Don't use ssb-db2 internals

### DIFF
--- a/messages.js
+++ b/messages.js
@@ -1,6 +1,6 @@
 const crypto = require('crypto')
 const bb = require('ssb-bendy-butt')
-const { author, and, type, slowEqual } = require('ssb-db2/operators')
+const { where, author, and, type, toCallback } = require('ssb-db2/operators')
 const keys = require('./keys')
 
 // FIXME: define and use json schema
@@ -70,63 +70,64 @@ exports.init = function (sbot) {
     },
 
     tombstoneFeed(metafeedKeys, previousMsg, feedKeys, reason, cb) {
-      let query = and(author(metafeedKeys.id), type('metafeed/add'))
+      sbot.db.query(
+        where(and(author(metafeedKeys.id), type('metafeed/add'))),
+        toCallback((err, results) => {
+          if (err) return cb(err)
+          results = results.filter((x) => x.value.content.subfeed === feedKeys.id)
+          if (results.length === 0) return cb('no add message found on meta feed')
 
-      // FIXME: getJITDB() is not a public API
-      sbot.db.getJITDB().all(query, 0, false, false, (err, results) => {
-        if (err) return cb(err)
-        results = results.filter((x) => x.value.content.subfeed === feedKeys.id)
-        if (results.length === 0) return cb('no add message found on meta feed')
-
-        const content = {
-          type: 'metafeed/tombstone',
-          subfeed: feedKeys.id,
-          metafeed: metafeedKeys.id,
-          reason,
-          tangles: {
-            metafeed: {
-              root: results[0].key,
-              previous: results[results.length - 1].key,
+          const content = {
+            type: 'metafeed/tombstone',
+            subfeed: feedKeys.id,
+            metafeed: metafeedKeys.id,
+            reason,
+            tangles: {
+              metafeed: {
+                root: results[0].key,
+                previous: results[results.length - 1].key,
+              },
             },
-          },
-        }
+          }
 
-        const sequence = previousMsg ? previousMsg.value.sequence + 1 : 1
-        const previous = previousMsg ? previousMsg.key : null
-        const timestamp = Date.now()
-        const bbmsg = bb.encodeNew(
-          content,
-          feedKeys,
-          metafeedKeys,
-          sequence,
-          previous,
-          timestamp
-        )
-        const msgVal = bb.decode(bbmsg)
+          const sequence = previousMsg ? previousMsg.value.sequence + 1 : 1
+          const previous = previousMsg ? previousMsg.key : null
+          const timestamp = Date.now()
+          const bbmsg = bb.encodeNew(
+            content,
+            feedKeys,
+            metafeedKeys,
+            sequence,
+            previous,
+            timestamp
+          )
+          const msgVal = bb.decode(bbmsg)
 
-        cb(null, msgVal)
-      })
+          cb(null, msgVal)
+        })
+      )
     },
 
     generateAnnounceMsg(metafeedKeys, cb) {
-      let query = and(author(sbot.id), type('metafeed/announce'))
+      sbot.db.query(
+        where(and(author(sbot.id), type('metafeed/announce'))),
+        toCallback((err, results) => {
+          if (err) return cb(err)
+          const rootAnnounceId = results.length > 0 ? results[0].key : null
+          const previousAnnounceId =
+            results.length > 0 ? results[results.length - 1].key : null
 
-      // FIXME: getJITDB() is not a public API
-      sbot.db.getJITDB().all(query, 0, false, false, (err, results) => {
-        const rootAnnounceId = results.length > 0 ? results[0].key : null
-        const previousAnnounceId =
-          results.length > 0 ? results[results.length - 1].key : null
+          const msg = {
+            type: 'metafeed/announce',
+            metafeed: metafeedKeys.id,
+            tangles: {
+              metafeed: { root: rootAnnounceId, previous: previousAnnounceId },
+            },
+          }
 
-        const msg = {
-          type: 'metafeed/announce',
-          metafeed: metafeedKeys.id,
-          tangles: {
-            metafeed: { root: rootAnnounceId, previous: previousAnnounceId },
-          },
-        }
-
-        cb(null, msg)
-      })
+          cb(null, msg)
+        })
+      )
     },
 
     generateSeedSaveMsg(metafeedId, mainfeedId, seed) {

--- a/metafeed.js
+++ b/metafeed.js
@@ -19,21 +19,18 @@ exports.init = function (sbot, config) {
     sbot.db.publishAs(metafeed.keys, addMsg, (err) => {
       if (err) return cb(err)
 
-      // FIXME: onDrain is not a public API
-      sbot.db.onDrain('base', () => {
-        sbot.metafeeds.query.hydrate(
-          metafeed.keys.id,
-          metafeed.seed,
-          (err, hydrated) => {
-            metafeed.feeds = hydrated.feeds
+      sbot.metafeeds.query.hydrate(
+        metafeed.keys.id,
+        metafeed.seed,
+        (err, hydrated) => {
+          metafeed.feeds = hydrated.feeds
 
-            cb(
-              null,
-              metafeed.feeds.find((f) => f.feedpurpose == feedpurpose)
-            )
-          }
-        )
-      })
+          cb(
+            null,
+            metafeed.feeds.find((f) => f.feedpurpose == feedpurpose)
+          )
+        }
+      )
     })
   }
 
@@ -96,17 +93,14 @@ exports.init = function (sbot, config) {
             sbot.db.publishAs(mf.keys, addMsg, (err) => {
               if (err) return cb(err)
               else {
-                // FIXME: onDrain() is not a public API
-                sbot.db.onDrain('base', () => {
-                  sbot.metafeeds.query.hydrate(
-                    mf.keys.id,
-                    mf.seed,
-                    (err, hydrated) => {
-                      Object.assign(mf, hydrated)
-                      cb(err, mf)
-                    }
-                  )
-                })
+                sbot.metafeeds.query.hydrate(
+                  mf.keys.id,
+                  mf.seed,
+                  (err, hydrated) => {
+                    Object.assign(mf, hydrated)
+                    cb(err, mf)
+                  }
+                )
               }
             })
           } else {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "bipf": "^1.5.1",
     "futoin-hkdf": "^1.3.3",
-    "jitdb": "^3.1.4",
     "pull-stream": "^3.6.14",
     "ssb-bendy-butt": "~0.8.0",
     "ssb-db2": "github:ssb-ngi-pointer/ssb-db2#publishAs-simple",

--- a/test/metafeed.js
+++ b/test/metafeed.js
@@ -4,8 +4,7 @@ const path = require('path')
 const rimraf = require('rimraf')
 const SecretStack = require('secret-stack')
 const caps = require('ssb-caps')
-
-const { author } = require('ssb-db2/operators')
+const { author, where, toCallback } = require('ssb-db2/operators')
 
 const dir = '/tmp/metafeeds-metafeed'
 const mainKey = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
@@ -22,24 +21,26 @@ let sbot = SecretStack({ appKey: caps.shs })
 let db = sbot.db
 
 test('Base', (t) => {
-  // FIXME: getJITDB() is not a public API
-  db.getJITDB().all(author(mainKey.id), 0, false, false, (err, results) => {
-    t.equals(results.length, 0, 'empty db')
+  db.query(
+    where(author(mainKey.id)),
+    toCallback((err, results) => {
+      t.equals(results.length, 0, 'empty db')
 
-    sbot.metafeeds.metafeed.getOrCreate((err, mf) => {
-      t.equals(mf.feeds.length, 1, '1 feed')
-      t.equals(mf.feeds[0].feedpurpose, 'main', 'is main feed')
-      t.equals(mf.seed.toString('hex').length, 64, 'seed')
-      t.equals(typeof mf.keys.id, 'string', 'keys')
+      sbot.metafeeds.metafeed.getOrCreate((err, mf) => {
+        t.equals(mf.feeds.length, 1, '1 feed')
+        t.equals(mf.feeds[0].feedpurpose, 'main', 'is main feed')
+        t.equals(mf.seed.toString('hex').length, 64, 'seed')
+        t.equals(typeof mf.keys.id, 'string', 'keys')
 
-      // lets create a new chess feed
-      mf.getOrCreateFeed('chess', 'classic', (err, feed) => {
-        t.equals(mf.feeds.length, 2, '2 feeds')
-        t.equals(feed.feedpurpose, 'chess', 'chess feed')
-        sbot.close(t.end)
+        // lets create a new chess feed
+        mf.getOrCreateFeed('chess', 'classic', (err, feed) => {
+          t.equals(mf.feeds.length, 2, '2 feeds')
+          t.equals(feed.feedpurpose, 'chess', 'chess feed')
+          sbot.close(t.end)
+        })
       })
     })
-  })
+  )
 })
 
 test('Restart', (t) => {

--- a/test/query.js
+++ b/test/query.js
@@ -63,25 +63,22 @@ test('metafeed with multiple feeds', (t) => {
 
     db.publishAs(metafeedKeys, indexAddMsg, (err, m) => {
       indexMsg = m
-      // FIXME: onDrain is not a public API
-      db.onDrain('base', () => {
-        sbot.metafeeds.query.hydrate(metafeedKeys.id, seed, (err, hydrated) => {
-          t.equal(hydrated.feeds.length, 2, 'multiple feeds')
-          t.equal(hydrated.feeds[0].feedpurpose, 'main')
-          t.equal(
-            hydrated.feeds[0].subfeed,
-            hydrated.feeds[0].keys.id,
-            'correct main keys'
-          )
-          t.equal(typeof hydrated.feeds[0].keys.id, 'string', 'has key')
-          t.equal(hydrated.feeds[1].feedpurpose, 'index')
-          t.equal(
-            hydrated.feeds[1].subfeed,
-            hydrated.feeds[1].keys.id,
-            'correct index keys'
-          )
-          t.end()
-        })
+      sbot.metafeeds.query.hydrate(metafeedKeys.id, seed, (err, hydrated) => {
+        t.equal(hydrated.feeds.length, 2, 'multiple feeds')
+        t.equal(hydrated.feeds[0].feedpurpose, 'main')
+        t.equal(
+          hydrated.feeds[0].subfeed,
+          hydrated.feeds[0].keys.id,
+          'correct main keys'
+        )
+        t.equal(typeof hydrated.feeds[0].keys.id, 'string', 'has key')
+        t.equal(hydrated.feeds[1].feedpurpose, 'index')
+        t.equal(
+          hydrated.feeds[1].subfeed,
+          hydrated.feeds[1].keys.id,
+          'correct index keys'
+        )
+        t.end()
       })
     })
   })
@@ -104,23 +101,12 @@ test('metafeed with tombstones', (t) => {
     reason,
     (err, msg) => {
       db.publishAs(metafeedKeys, msg, (err) => {
-        // FIXME: onDrain is not a public API
-        db.onDrain('base', () => {
-          sbot.metafeeds.query.hydrate(
-            metafeedKeys.id,
-            seed,
-            (err, hydrated) => {
-              t.equal(hydrated.feeds.length, 1, 'single feed')
-              t.equal(hydrated.feeds[0].feedpurpose, 'main')
-              t.equal(hydrated.tombstoned.length, 1, '1 tombstone')
-              t.equal(
-                hydrated.tombstoned[0].subfeed,
-                indexKey.id,
-                'tombstone id'
-              )
-              t.end()
-            }
-          )
+        sbot.metafeeds.query.hydrate(metafeedKeys.id, seed, (err, hydrated) => {
+          t.equal(hydrated.feeds.length, 1, 'single feed')
+          t.equal(hydrated.feeds[0].feedpurpose, 'main')
+          t.equal(hydrated.tombstoned.length, 1, '1 tombstone')
+          t.equal(hydrated.tombstoned[0].subfeed, indexKey.id, 'tombstone id')
+          t.end()
         })
       })
     }
@@ -130,12 +116,9 @@ test('metafeed with tombstones', (t) => {
 test('seed', (t) => {
   const msg = messages.generateSeedSaveMsg(metafeedKeys.id, sbot.id, seed)
   db.publish(msg, (err) => {
-    // FIXME: onDrain is not a public API
-    db.onDrain('base', () => {
-      sbot.metafeeds.query.getSeed((err, storedSeed) => {
-        t.deepEqual(storedSeed, seed, 'correct seed')
-        t.end()
-      })
+    sbot.metafeeds.query.getSeed((err, storedSeed) => {
+      t.deepEqual(storedSeed, seed, 'correct seed')
+      t.end()
     })
   })
 })
@@ -144,12 +127,9 @@ test('announce', (t) => {
   messages.generateAnnounceMsg(metafeedKeys.id, (err, msg) => {
     db.publish(msg, (err, publishedAnnounce) => {
       t.error(err, 'no err')
-      // FIXME: onDrain is not a public API
-      db.onDrain('base', () => {
-        sbot.metafeeds.query.getAnnounce((err, storedAnnounce) => {
-          t.equal(publishedAnnounce.key, storedAnnounce.key, 'correct announce')
-          sbot.close(t.end)
-        })
+      sbot.metafeeds.query.getAnnounce((err, storedAnnounce) => {
+        t.equal(publishedAnnounce.key, storedAnnounce.key, 'correct announce')
+        sbot.close(t.end)
       })
     })
   })


### PR DESCRIPTION
Removed uses of `ssb.db.onDrain()` and `ssb.db.getJITDB()`, as those are internal APIs.

The diff looks crazy, but just because indentation changed, otherwise it's rather simple PR.