### PR TITLE
replace publishAs() with add() for bendy butt msgs

### DIFF
--- a/api.js
+++ b/api.js
@@ -113,7 +113,7 @@ exports.init = function (sbot, config) {
       if (!details.feedformat) return cb(new Error('Missing feedformat'))
       sbot.metafeeds.query.getLatest(metafeed.keys.id, (err, latest) => {
         if (err) return cb(err)
-        const msgVal = sbot.metafeeds.messages.msgValAddDerived(
+        const msgVal = sbot.metafeeds.messages.getMsgValAddDerived(
           metafeed.keys,
           latest,
           details.feedpurpose,
@@ -154,7 +154,7 @@ exports.init = function (sbot, config) {
     // Pluck relevant internal APIs
     const { deriveRootMetaFeedKeyFromSeed } = sbot.metafeeds.keys
     const { getSeed, getAnnounces, getLatest } = sbot.metafeeds.query
-    const { contentSeed, contentAnnounce, msgValAddExisting } =
+    const { getContentSeed, getContentAnnounce, getMsgValAddExisting } =
       sbot.metafeeds.messages
 
     // Ensure seed exists
@@ -165,7 +165,7 @@ exports.init = function (sbot, config) {
       else debug('generating a seed')
       const seed = sbot.metafeeds.keys.generateSeed()
       const mfKeys = deriveRootMetaFeedKeyFromSeed(seed)
-      const content = contentSeed(mfKeys.id, sbot.id, seed)
+      const content = getContentSeed(mfKeys.id, sbot.id, seed)
       const [err2] = await run(sbot.db.publish)(content)
       if (err2) return cb(err2)
       mf = { seed, keys: mfKeys }
@@ -180,7 +180,7 @@ exports.init = function (sbot, config) {
     if (err2 || !announcements || announcements.length === 0) {
       if (err2) debug('announcing meta feed on main feed because %o', err2)
       else debug('announcing meta feed on main feed')
-      const [err3, content] = await run(contentAnnounce)(mf.keys)
+      const [err3, content] = await run(getContentAnnounce)(mf.keys)
       if (err3) return cb(err3)
       const [err4] = await run(sbot.db.publish)(content)
       if (err4) return cb(err4)
@@ -195,7 +195,7 @@ exports.init = function (sbot, config) {
       const [err4, latest] = await run(getLatest)(mf.keys.id)
       if (err4) return cb(err4)
       debug('adding main feed to root meta feed')
-      const msgVal = msgValAddExisting(mf.keys, latest, 'main', config.keys)
+      const msgVal = getMsgValAddExisting(mf.keys, latest, 'main', config.keys)
       const [err5] = await run(sbot.db.add)(msgVal)
       if (err5) return cb(err5)
     } else {

--- a/api.js
+++ b/api.js
@@ -113,7 +113,7 @@ exports.init = function (sbot, config) {
       if (!details.feedformat) return cb(new Error('Missing feedformat'))
       sbot.metafeeds.query.getLatest(metafeed.keys.id, (err, latest) => {
         if (err) return cb(err)
-        const msgValAdd = sbot.metafeeds.messages.addNewFeed(
+        const msgVal = sbot.metafeeds.messages.msgValAddDerived(
           metafeed.keys,
           latest,
           details.feedpurpose,
@@ -121,7 +121,7 @@ exports.init = function (sbot, config) {
           details.feedformat,
           details.metadata
         )
-        sbot.db.publishAs(metafeed.keys, msgValAdd, (err, msg) => {
+        sbot.db.add(msgVal, (err, msg) => {
           if (err) return cb(err)
           const hydratedSubfeed = sbot.metafeeds.query.hydrateFromMsg(
             msg,
@@ -154,7 +154,7 @@ exports.init = function (sbot, config) {
     // Pluck relevant internal APIs
     const { deriveRootMetaFeedKeyFromSeed } = sbot.metafeeds.keys
     const { getSeed, getAnnounces, getLatest } = sbot.metafeeds.query
-    const { generateSeedSaveMsg, generateAnnounceMsg, addExistingFeed } =
+    const { contentSeed, contentAnnounce, msgValAddExisting } =
       sbot.metafeeds.messages
 
     // Ensure seed exists
@@ -165,8 +165,8 @@ exports.init = function (sbot, config) {
       else debug('generating a seed')
       const seed = sbot.metafeeds.keys.generateSeed()
       const mfKeys = deriveRootMetaFeedKeyFromSeed(seed)
-      const seedSaveMsg = generateSeedSaveMsg(mfKeys.id, sbot.id, seed)
-      const [err2] = await run(sbot.db.publish)(seedSaveMsg)
+      const content = contentSeed(mfKeys.id, sbot.id, seed)
+      const [err2] = await run(sbot.db.publish)(content)
       if (err2) return cb(err2)
       mf = { seed, keys: mfKeys }
     } else {
@@ -180,9 +180,9 @@ exports.init = function (sbot, config) {
     if (err2 || !announcements || announcements.length === 0) {
       if (err2) debug('announcing meta feed on main feed because %o', err2)
       else debug('announcing meta feed on main feed')
-      const [err3, announceMsgVal] = await run(generateAnnounceMsg)(mf.keys)
+      const [err3, content] = await run(contentAnnounce)(mf.keys)
       if (err3) return cb(err3)
-      const [err4] = await run(sbot.db.publish)(announceMsgVal)
+      const [err4] = await run(sbot.db.publish)(content)
       if (err4) return cb(err4)
     } else {
       debug('announce post exists on main feed')
@@ -195,8 +195,8 @@ exports.init = function (sbot, config) {
       const [err4, latest] = await run(getLatest)(mf.keys.id)
       if (err4) return cb(err4)
       debug('adding main feed to root meta feed')
-      const addMsgVal = addExistingFeed(mf.keys, latest, 'main', config.keys)
-      const [err5] = await run(sbot.db.publishAs)(mf.keys, addMsgVal)
+      const msgVal = msgValAddExisting(mf.keys, latest, 'main', config.keys)
+      const [err5] = await run(sbot.db.add)(msgVal)
       if (err5) return cb(err5)
     } else {
       debug('main feed already added to root meta feed')

--- a/messages.js
+++ b/messages.js
@@ -67,10 +67,10 @@ exports.init = function init(sbot) {
      * optional object to be included (object spread) in `msg.value.content`.
      *
      * ```js
-     * const msg = sbot.metafeeds.messages.msgValAddExisting(metafeedKeys, null, 'main', mainKeys)
+     * const msg = sbot.metafeeds.messages.getMsgValAddExisting(metafeedKeys, null, 'main', mainKeys)
      * ```
      */
-    msgValAddExisting(mfKeys, previous, feedpurpose, feedKeys, metadata) {
+    getMsgValAddExisting(mfKeys, previous, feedpurpose, feedKeys, metadata) {
       return add(feedpurpose, undefined, previous, feedKeys, mfKeys, metadata)
     },
 
@@ -81,10 +81,10 @@ exports.init = function init(sbot) {
      * object to be included (object spread) in `msg.value.content`.
      *
      * ```js
-     * const msg = sbot.metafeeds.messages.msgValAddDerived(metafeedKeys, null, 'main', seed, 'classic')
+     * const msg = sbot.metafeeds.messages.getMsgValAddDerived(metafeedKeys, null, 'main', seed, 'classic')
      * ```
      */
-    msgValAddDerived(
+    getMsgValAddDerived(
       mfKeys,
       previous,
       feedpurpose,
@@ -118,14 +118,14 @@ exports.init = function init(sbot) {
      *   }
      * }
      *
-     * sbot.metafeeds.messages.msgValTombstone(metafeedKeys, previous, mainKeys, 'No longer used', (err, tombstoneMsg) => {
+     * sbot.metafeeds.messages.getMsgValTombstone(metafeedKeys, previous, mainKeys, 'No longer used', (err, tombstoneMsg) => {
      *   sbot.db.add(tombstoneMsg, (err) => {
      *     console.log("main is now tombstoned on meta feed")
      *   })
      * })
      * ```
      */
-    msgValTombstone(mfKeys, previousMsg, feedKeys, reason, cb) {
+    getMsgValTombstone(mfKeys, previousMsg, feedKeys, reason, cb) {
       sbot.db.query(
         where(
           and(
@@ -176,14 +176,14 @@ exports.init = function init(sbot) {
      * it to a meta feed.
      *
      * ```js
-     * sbot.metafeeds.messages.contentAnnounce(metafeedKeys, (err, content) => {
+     * sbot.metafeeds.messages.getContentAnnounce(metafeedKeys, (err, content) => {
      *   sbot.db.publish(content, (err) => {
      *     console.log("main feed is now linked to meta feed")
      *   })
      * })
      * ```
      */
-    contentAnnounce(metafeedKeys, cb) {
+    getContentAnnounce(metafeedKeys, cb) {
       sbot.db.query(
         where(and(author(sbot.id), type('metafeed/announce'))),
         toCallback((err, msgs) => {
@@ -213,13 +213,13 @@ exports.init = function init(sbot) {
      * message on a main feed.
      *
      * ```js
-     * const seedContent = sbot.metafeeds.messages.contentSeed(metafeedKeys.id, sbot.id, seed)
+     * const seedContent = sbot.metafeeds.messages.getContentSeed(metafeedKeys.id, sbot.id, seed)
      * sbot.db.publish(seedContent, (err) => {
      *   console.log("seed has now been saved, all feed keys generated from this can be restored from the seed")
      * })
      * ```
      */
-    contentSeed(metafeedId, mainfeedId, seed) {
+    getContentSeed(metafeedId, mainfeedId, seed) {
       return {
         type: 'metafeed/seed',
         metafeed: metafeedId,

--- a/messages.js
+++ b/messages.js
@@ -67,10 +67,10 @@ exports.init = function init(sbot) {
      * optional object to be included (object spread) in `msg.value.content`.
      *
      * ```js
-     * const msg = sbot.metafeeds.messages.addExistingFeed(metafeedKeys, null, 'main', mainKeys)
+     * const msg = sbot.metafeeds.messages.msgValAddExisting(metafeedKeys, null, 'main', mainKeys)
      * ```
      */
-    addExistingFeed(mfKeys, previous, feedpurpose, feedKeys, metadata) {
+    msgValAddExisting(mfKeys, previous, feedpurpose, feedKeys, metadata) {
       return add(feedpurpose, undefined, previous, feedKeys, mfKeys, metadata)
     },
 
@@ -81,10 +81,17 @@ exports.init = function init(sbot) {
      * object to be included (object spread) in `msg.value.content`.
      *
      * ```js
-     * const msg = sbot.metafeeds.messages.addNewFeed(metafeedKeys, null, 'main', seed, 'classic')
+     * const msg = sbot.metafeeds.messages.msgValAddDerived(metafeedKeys, null, 'main', seed, 'classic')
      * ```
      */
-    addNewFeed(mfKeys, previous, feedpurpose, seed, feedformat, metadata) {
+    msgValAddDerived(
+      mfKeys,
+      previous,
+      feedpurpose,
+      seed,
+      feedformat,
+      metadata
+    ) {
       if (feedformat !== 'classic' && feedformat !== 'bendy butt') {
         throw new Error('Unknown feed format: ' + feedformat)
       }
@@ -111,14 +118,14 @@ exports.init = function init(sbot) {
      *   }
      * }
      *
-     * sbot.metafeeds.messages.tombstoneFeed(metafeedKeys, previous, mainKeys, 'No longer used', (err, tombstoneMsg) => {
-     *   sbot.db.publishAs(mfKey, tombstoneMsg, (err) => {
+     * sbot.metafeeds.messages.msgValTombstone(metafeedKeys, previous, mainKeys, 'No longer used', (err, tombstoneMsg) => {
+     *   sbot.db.add(tombstoneMsg, (err) => {
      *     console.log("main is now tombstoned on meta feed")
      *   })
      * })
      * ```
      */
-    tombstoneFeed(mfKeys, previousMsg, feedKeys, reason, cb) {
+    msgValTombstone(mfKeys, previousMsg, feedKeys, reason, cb) {
       sbot.db.query(
         where(
           and(
@@ -169,14 +176,14 @@ exports.init = function init(sbot) {
      * it to a meta feed.
      *
      * ```js
-     * sbot.metafeeds.messages.generateAnnounceMsg(metafeedKeys, (err, announceMsg) => {
-     *   sbot.db.publish(announceMsg, (err) => {
+     * sbot.metafeeds.messages.contentAnnounce(metafeedKeys, (err, content) => {
+     *   sbot.db.publish(content, (err) => {
      *     console.log("main feed is now linked to meta feed")
      *   })
      * })
      * ```
      */
-    generateAnnounceMsg(metafeedKeys, cb) {
+    contentAnnounce(metafeedKeys, cb) {
       sbot.db.query(
         where(and(author(sbot.id), type('metafeed/announce'))),
         toCallback((err, msgs) => {
@@ -185,7 +192,7 @@ exports.init = function init(sbot) {
           const previousAnnounceId =
             msgs.length > 0 ? msgs[msgs.length - 1].key : null
 
-          const msg = {
+          const content = {
             type: 'metafeed/announce',
             metafeed: metafeedKeys.id,
             tangles: {
@@ -196,7 +203,7 @@ exports.init = function init(sbot) {
             },
           }
 
-          cb(null, msg)
+          cb(null, content)
         })
       )
     },
@@ -206,13 +213,13 @@ exports.init = function init(sbot) {
      * message on a main feed.
      *
      * ```js
-     * const seedSaveMsg = sbot.metafeeds.messages.generateSeedSaveMsg(metafeedKeys.id, sbot.id, seed)
-     * sbot.db.publish(seedSaveMsg, (err) => {
+     * const seedContent = sbot.metafeeds.messages.contentSeed(metafeedKeys.id, sbot.id, seed)
+     * sbot.db.publish(seedContent, (err) => {
      *   console.log("seed has now been saved, all feed keys generated from this can be restored from the seed")
      * })
      * ```
      */
-    generateSeedSaveMsg(metafeedId, mainfeedId, seed) {
+    contentSeed(metafeedId, mainfeedId, seed) {
       return {
         type: 'metafeed/seed',
         metafeed: metafeedId,

--- a/test/messages.js
+++ b/test/messages.js
@@ -29,7 +29,12 @@ let messages = sbot.metafeeds.messages
 let addMsg
 
 test('add a feed to metafeed', (t) => {
-  const msgVal = messages.msgValAddExisting(metafeedKeys, null, 'main', mainKey)
+  const msgVal = messages.getMsgValAddExisting(
+    metafeedKeys,
+    null,
+    'main',
+    mainKey
+  )
 
   t.true(
     msgVal.contentSignature.endsWith('.sig.ed25519'),
@@ -50,7 +55,7 @@ let tombstoneMsg
 test('tombstone a feed in a metafeed', (t) => {
   const reason = 'Feed no longer used'
 
-  messages.msgValTombstone(
+  messages.getMsgValTombstone(
     metafeedKeys,
     addMsg,
     mainKey,
@@ -78,7 +83,7 @@ test('tombstone a feed in a metafeed', (t) => {
 })
 
 test('second tombstone', (t) => {
-  const msgVal = messages.msgValAddDerived(
+  const msgVal = messages.getMsgValAddDerived(
     metafeedKeys,
     tombstoneMsg,
     'main',
@@ -92,7 +97,7 @@ test('second tombstone', (t) => {
   db.add(msgVal, (err, secondAddMsg) => {
     const reason = 'Also no good'
 
-    messages.msgValTombstone(
+    messages.getMsgValTombstone(
       metafeedKeys,
       secondAddMsg,
       newMainKey,
@@ -122,7 +127,7 @@ test('second tombstone', (t) => {
 })
 
 test('metafeed announce', (t) => {
-  messages.contentAnnounce(metafeedKeys, (err, content) => {
+  messages.getContentAnnounce(metafeedKeys, (err, content) => {
     t.equal(content.metafeed, metafeedKeys.id, 'correct metafeed')
     t.equal(content.tangles.metafeed.root, null, 'no root')
     t.equal(content.tangles.metafeed.previous, null, 'no previous')
@@ -131,7 +136,7 @@ test('metafeed announce', (t) => {
       // test that we fucked up somehow and need to create a new metafeed
       const newSeed = keys.generateSeed()
       const mf2Key = keys.deriveFeedKeyFromSeed(newSeed, 'metafeed')
-      messages.contentAnnounce(mf2Key, (err, content) => {
+      messages.getContentAnnounce(mf2Key, (err, content) => {
         t.equal(content.metafeed, mf2Key.id, 'correct metafeed')
         t.equal(content.tangles.metafeed.root, announceMsg.key, 'correct root')
         t.equal(
@@ -144,7 +149,7 @@ test('metafeed announce', (t) => {
           // another test to make sure previous is correctly set
           const newSeed2 = keys.generateSeed()
           const mf3Key = keys.deriveFeedKeyFromSeed(newSeed2, 'metafeed')
-          messages.contentAnnounce(mf3Key, (err, msg) => {
+          messages.getContentAnnounce(mf3Key, (err, msg) => {
             t.equal(msg.metafeed, mf3Key.id, 'correct metafeed')
             t.equal(msg.tangles.metafeed.root, announceMsg.key, 'correct root')
             t.equal(
@@ -162,7 +167,7 @@ test('metafeed announce', (t) => {
 })
 
 test('metafeed seed save', (t) => {
-  const content = messages.contentSeed(metafeedKeys.id, sbot.id, seed)
+  const content = messages.getContentSeed(metafeedKeys.id, sbot.id, seed)
 
   t.equal(content.metafeed, metafeedKeys.id, 'correct metafeed')
   t.equal(content.seed.length, 64, 'correct seed')

--- a/test/query.js
+++ b/test/query.js
@@ -30,7 +30,7 @@ let messages = sbot.metafeeds.messages
 let indexMsg, indexKey
 
 test('metafeed with multiple feeds', (t) => {
-  const classicAddMsgVal = messages.msgValAddExisting(
+  const classicAddMsgVal = messages.getMsgValAddExisting(
     metafeedKeys,
     null,
     'main',
@@ -38,7 +38,7 @@ test('metafeed with multiple feeds', (t) => {
   )
 
   db.add(classicAddMsgVal, (err, m) => {
-    const indexAddMsgVal = messages.msgValAddDerived(
+    const indexAddMsgVal = messages.getMsgValAddDerived(
       metafeedKeys,
       m,
       'index',
@@ -94,7 +94,7 @@ test('index metafeed', (t) => {
 test('metafeed with tombstones', (t) => {
   const reason = 'Feed no longer used'
 
-  messages.msgValTombstone(
+  messages.getMsgValTombstone(
     metafeedKeys,
     indexMsg,
     indexKey,
@@ -114,7 +114,7 @@ test('metafeed with tombstones', (t) => {
 })
 
 test('seed', (t) => {
-  const content = messages.contentSeed(metafeedKeys.id, sbot.id, seed)
+  const content = messages.getContentSeed(metafeedKeys.id, sbot.id, seed)
   db.publish(content, (err) => {
     sbot.metafeeds.query.getSeed((err, storedSeed) => {
       t.deepEqual(storedSeed, seed, 'correct seed')
@@ -124,7 +124,7 @@ test('seed', (t) => {
 })
 
 test('announce', (t) => {
-  messages.contentAnnounce(metafeedKeys.id, (err, content) => {
+  messages.getContentAnnounce(metafeedKeys.id, (err, content) => {
     db.publish(content, (err, publishedAnnounce) => {
       t.error(err, 'no err')
       sbot.metafeeds.query.getAnnounces((err, announcements) => {

--- a/test/query.js
+++ b/test/query.js
@@ -30,15 +30,15 @@ let messages = sbot.metafeeds.messages
 let indexMsg, indexKey
 
 test('metafeed with multiple feeds', (t) => {
-  const classicAddMsg = messages.addExistingFeed(
+  const classicAddMsgVal = messages.msgValAddExisting(
     metafeedKeys,
     null,
     'main',
     mainKey
   )
 
-  db.publishAs(metafeedKeys, classicAddMsg, (err, m) => {
-    const indexAddMsg = messages.addNewFeed(
+  db.add(classicAddMsgVal, (err, m) => {
+    const indexAddMsgVal = messages.msgValAddDerived(
       metafeedKeys,
       m,
       'index',
@@ -57,11 +57,11 @@ test('metafeed with multiple feeds', (t) => {
 
     indexKey = keys.deriveFeedKeyFromSeed(
       seed,
-      indexAddMsg.content.nonce.toString('base64'),
+      indexAddMsgVal.content.nonce.toString('base64'),
       'classic'
     )
 
-    db.publishAs(metafeedKeys, indexAddMsg, (err, m) => {
+    db.add(indexAddMsgVal, (err, m) => {
       indexMsg = m
       sbot.metafeeds.query.hydrate(metafeedKeys.id, seed, (err, hydrated) => {
         t.equal(hydrated.feeds.length, 2, 'multiple feeds')
@@ -94,13 +94,13 @@ test('index metafeed', (t) => {
 test('metafeed with tombstones', (t) => {
   const reason = 'Feed no longer used'
 
-  messages.tombstoneFeed(
+  messages.msgValTombstone(
     metafeedKeys,
     indexMsg,
     indexKey,
     reason,
-    (err, msg) => {
-      db.publishAs(metafeedKeys, msg, (err) => {
+    (err, msgVal) => {
+      db.add(msgVal, (err) => {
         sbot.metafeeds.query.hydrate(metafeedKeys.id, seed, (err, hydrated) => {
           t.equal(hydrated.feeds.length, 1, 'single feed')
           t.equal(hydrated.feeds[0].feedpurpose, 'main')
@@ -114,8 +114,8 @@ test('metafeed with tombstones', (t) => {
 })
 
 test('seed', (t) => {
-  const msg = messages.generateSeedSaveMsg(metafeedKeys.id, sbot.id, seed)
-  db.publish(msg, (err) => {
+  const content = messages.contentSeed(metafeedKeys.id, sbot.id, seed)
+  db.publish(content, (err) => {
     sbot.metafeeds.query.getSeed((err, storedSeed) => {
       t.deepEqual(storedSeed, seed, 'correct seed')
       t.end()
@@ -124,8 +124,8 @@ test('seed', (t) => {
 })
 
 test('announce', (t) => {
-  messages.generateAnnounceMsg(metafeedKeys.id, (err, msg) => {
-    db.publish(msg, (err, publishedAnnounce) => {
+  messages.contentAnnounce(metafeedKeys.id, (err, content) => {
+    db.publish(content, (err, publishedAnnounce) => {
       t.error(err, 'no err')
       sbot.metafeeds.query.getAnnounces((err, announcements) => {
         t.error(err, 'no err')


### PR DESCRIPTION
Follow up to https://github.com/ssb-ngi-pointer/ssb-db2/pull/248, I also changed the API names in `sbot.metafeeds.messages` to make it easier to remember:

- `msgValXXXX()` creates a `msgVal` for content.type `XXXX`
- `contentYYYY()` creates a `content` for type `YYYY`

Meta feed `msgVal`s use `db.add()` not `db.publishAs()`.