### PR TITLE
Bump ssb-db2 & bendy butt

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "dependencies": {
     "bipf": "^1.5.1",
     "debug": "^4.3.0",
-    "futoin-hkdf": "^1.3.3",
+    "futoin-hkdf": "^1.4.2",
     "promisify-tuple": "^1.2.0",
     "pull-stream": "^3.6.14",
-    "ssb-bendy-butt": "~0.10.0",
-    "ssb-db2": "github:ssb-ngi-pointer/ssb-db2#publishAs-simple",
+    "ssb-bendy-butt": "~0.11.0",
+    "ssb-db2": "github:ssb-ngi-pointer/ssb-db2#support-bendy-butt",
     "ssb-keys": "^8.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Simple bump some dependencies. Most important is the db2 so we can remove that branch.