### PR TITLE
Integrate validation checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,19 @@ possible error, and the 2nd argument is the found tombstoned feed.
 
 Exposed via the internal API.
 
+### `isValid(msg, hmacKey)`
+
+_Validate a single meta feed message._
+
+Extracts the `contentSection` from the given `msg` object and calls `validateSingle()` to perform validation checks.
+
+If provided, the `hmacKey` is also given as input to the `validateSingle()` function call. `hmacKey` may be `null` or a valid HMAC key supplied as a `Buffer` or `string`.
+
+The response is a boolean: `true` if validation is successful, `false` if validation fails in any way. Note that this function does not return the underlying cause of the validation failure.
+
 ### `validateSingle(contentSection, hmacKey)`
 
-_Validate a single meta feed message according to the criteria defined in the [specification](https://github.com/ssb-ngi-pointer/ssb-meta-feed-spec#usage-of-bendy-butt-feed-format)._
+_Validate a single meta feed message `contentSection` according to the criteria defined in the [specification](https://github.com/ssb-ngi-pointer/ssb-meta-feed-spec#usage-of-bendy-butt-feed-format)._
 
 `contentSection` must be an array of `content` and `contentSignature`. If a `string` is provided (representing an encrypted message, for instance) an error will be returned; an encrypted `contentSection` cannot be validated.
 

--- a/api.js
+++ b/api.js
@@ -124,7 +124,7 @@ exports.init = function (sbot, config) {
         )
         const contentSection = [msgVal.content, msgVal.contentSignature]
         const validationResult = validate.validateSingle(contentSection)
-        if (validationResult instanceof Error) return cb(err)
+        if (validationResult instanceof Error) return cb(validationResult)
         sbot.db.add(msgVal, (err, msg) => {
           if (err) return cb(err)
           const hydratedSubfeed = sbot.metafeeds.query.hydrateFromMsg(

--- a/api.js
+++ b/api.js
@@ -1,5 +1,6 @@
 const run = require('promisify-tuple')
 const debug = require('debug')('ssb:meta-feeds')
+const validate = require('./validate')
 
 const alwaysTrue = () => true
 
@@ -121,6 +122,9 @@ exports.init = function (sbot, config) {
           details.feedformat,
           details.metadata
         )
+        const contentSection = [msgVal.content, msgVal.contentSignature]
+        const validationResult = validate.validateSingle(contentSection)
+        if (validationResult instanceof Error) return cb(err)
         sbot.db.add(msgVal, (err, msg) => {
           if (err) return cb(err)
           const hydratedSubfeed = sbot.metafeeds.query.hydrateFromMsg(

--- a/query.js
+++ b/query.js
@@ -93,9 +93,8 @@ exports.init = function (sbot, config) {
         toCallback((err, msgs) => {
           if (err) return cb(err)
 
-          msgs = msgs.filter((msg) =>
-            msg.value.content.type.startsWith('metafeed/add/')
-          )
+          msgs = msgs.filter((msg) => validate.isValid(msg))
+
           // FIXME: handle multiple msgs properly?
           cb(null, msgs.length > 0 ? msgs[0].value.content : null)
         })
@@ -181,21 +180,7 @@ exports.init = function (sbot, config) {
         toCallback((err, msgs) => {
           if (err) return cb(err)
 
-          const validatedMsgs = msgs
-            .filter((msg) => msg.value.content.type.startsWith('metafeed/'))
-            .map((msg) => {
-              if (msg.value.content && msg.value.contentSignature) {
-                const contentSection = [
-                  msg.value.content,
-                  msg.value.contentSignature,
-                ]
-                const validationResult = validate.validateSingle(
-                  contentSection,
-                  null
-                )
-                if (validationResult === undefined) return msg
-              }
-            })
+          const validatedMsgs = msgs.filter((msg) => validate.isValid(msg))
 
           const addedFeeds = validatedMsgs
             .filter((msg) => msg.value.content.type.startsWith('metafeed/add/'))

--- a/validate.js
+++ b/validate.js
@@ -20,6 +20,8 @@ function isValid(msg, hmacKey) {
     const validationResult = validateSingle(contentSection, hmacKey)
 
     return validationResult === undefined
+  } else {
+    return false
   }
 }
 

--- a/validate.js
+++ b/validate.js
@@ -10,11 +10,27 @@ const CONTENT_SIG_PREFIX = Buffer.from('bendybutt', 'utf8')
 /**
  * Validate a single meta feed message.
  *
+ * @param {Object} msg - a meta feed message in the form of a JSON object
+ * @param {Buffer | string | null} hmacKey - a valid HMAC key for signature verification
+ * @returns {true | false} `true` in the case of successful validation
+ */
+function isValid(msg, hmacKey) {
+  if (msg.value.content && msg.value.contentSignature) {
+    const contentSection = [msg.value.content, msg.value.contentSignature]
+    const validationResult = validateSingle(contentSection, hmacKey)
+
+    return validationResult === undefined
+  }
+}
+
+/**
+ * Validate a single meta feed message `contentSection`.
+ *
  * @param {Array | string} contentSection - an array of `content` and `contentSignature` or an encrypted string
  * @param {Buffer | string | null} hmacKey - a valid HMAC key for signature verification
- * @returns {Object | true} an `Error` object or `true` in the case of successful validation
+ * @returns {Object | true} an `Error` object or `undefined` in the case of successful validation
  */
-exports.validateSingle = function (contentSection, hmacKey) {
+function validateSingle(contentSection, hmacKey) {
   if (contentSection === null || contentSection === undefined)
     return new Error(
       `invalid message: contentSection cannot be null or undefined`
@@ -154,3 +170,6 @@ function validateHmacKey(hmacKey) {
       `invalid hmac key: "${hmacKey}" with length ${hmacKey.length}, expected 32 bytes`
     )
 }
+
+exports.isValid = isValid
+exports.validateSingle = validateSingle


### PR DESCRIPTION
Now that we have a means of validating the `contentSection` of a meta feeds message, we can begin to use it in this module (and others).

I'm beginning by adding a simple check before `sbot.db.add` is called in the `create` function. I believe this results in the validation check being called on three occasions in the current test suite:

`findOrCreate() a sub feed`
`findOrCreate() a sub meta feed`
`findOrCreate() a subfeed under a sub meta feed`