### PR TITLE
Update subfeed prefix offset value (account for SSB URIs)

### DIFF
--- a/query.js
+++ b/query.js
@@ -11,6 +11,12 @@ const {
 } = require('ssb-db2/operators')
 const SSBURI = require('ssb-uri2')
 
+const SUBFEED_PREFIX_OFFSET = Math.max(
+  '@'.length,
+  'ssb:feed/bendybutt-v1/'.length,
+  'ssb:feed/gabbygrove-v1/'.length
+)
+
 function subfeed(feedId) {
   const B_VALUE = Buffer.from('value')
   const B_CONTENT = Buffer.from('content')
@@ -27,7 +33,7 @@ function subfeed(feedId) {
 
   return equal(seekSubfeed, feedId, {
     prefix: 32,
-    prefixOffset: 1,
+    prefixOffset: SUBFEED_PREFIX_OFFSET,
     indexType: 'value_content_subfeed',
   })
 }


### PR DESCRIPTION
Takes SSB URIs for `bendybutt-v1` and `gabbygrove-v1` into account when calculating and assigning the `prefixOffset` for the subfeed `equal()` db2 operator call

In response to: https://github.com/ssb-ngi-pointer/ssb-meta-feeds/issues/38

-----

A question which came up for me while making this PR:

Would it be more efficient (or accurate) to calculate the required `prefixOffset` based on the given `feedId`, rather than using the max length as offset for all cases?