### PR TITLE
Support gabby grove in deriveFeedKeyFromSeed

### DIFF
--- a/keys.js
+++ b/keys.js
@@ -38,7 +38,7 @@ const keys = {
    * ```
    * @param {Buffer} seed
    * @param {string} label
-   * @param {'bendybutt-v1' | 'classic'} format default is 'classic'
+   * @param {'bendybutt-v1' | 'gabbygrove-v1' | 'classic'} format default is 'classic'
    */
   deriveFeedKeyFromSeed(seed, label, format) {
     if (!label) throw new Error('label was not supplied')
@@ -51,7 +51,7 @@ const keys = {
       hash: 'SHA-256',
     })
     const keys = ssbKeys.generate('ed25519', derived_seed)
-    if (format === 'bendybutt-v1') {
+    if (format === 'bendybutt-v1' || format === 'gabbygrove-v1') {
       const classicUri = SSBURI.fromFeedSigil(keys.id)
       const { type, /* format, */ data } = SSBURI.decompose(classicUri)
       const bendyButtUri = SSBURI.compose({ type, format, data })


### PR DESCRIPTION
Adds a check for `gabbygrove-v1` when deriving a feed key from seed. This ensures that Gabby Grove is treated in the same way as Bendy Butt when deriving the key (preventing the default behaviour, which is to handle it as a classic format).

Related to: https://github.com/ssb-ngi-pointer/ssb-bendy-butt/pull/35#discussion_r703382283