### PR TITLE
introduce findById()

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Add this plugin like this:
 
 ## Example usage
 
-Let's start by creating a **root meta feed**, necessary for using this module. It
-lives alongside your existing "classical" feed, which we'll refer to as **main
-feed**.
+Let's start by creating a **root meta feed**, necessary for using this module.
+It lives alongside your existing "classical" feed, which we'll refer to as
+**main feed**.
 
 ```js
 sbot.metafeeds.create((err, metafeed) => {
@@ -139,25 +139,21 @@ sbot.metafeeds.findOrCreate(
 
 ## API
 
-### `sbot.metafeeds.filter(metafeed, visit, cb)`
+Some of these APIs can only be used on feeds that **you own** (🌻) while other
+APIs can be used on any feed (🌷), i.e. feeds created by other peers.
 
-_Looks for all subfeeds of `metafeed` that satisfy the condition in `visit`._
+### 🌷 `sbot.metafeeds.findById(feedId, cb)`
 
-`metafeed` can be either `null` or a meta feed object `{ seed, keys }` (as
-returned by `create()`). If it's null, then the result will be an array
-containing one item, the root meta feed, or zero items if the root meta feed
-does not exist.
+Given a `feedId` that is presumed to be a subfeed of some meta feed, this API
+fetches the metadata associated with the creation of this subfeed on its parent
+meta feed, and returns (via the callback `cb` on the second argument) an object
+with the following shape:
 
-`visit` can be either `null` or a function of the shape
-`({feedpurpose,subfeed,keys}) => boolean`. If it's null, then all subfeeds under
-`metafeed` are returned.
+```
+{ feedpurpose, feedformat, metafeed, metafeed }
+```
 
-The response is delivered to the callback `cb`, where the 1st argument is the
-possible error, and the 2nd argument is an array containing the found feeds
-(which can be either the root meta feed `{ seed, keys }` or a sub feed
-`{ feedpurpose, subfeed, keys, metadata }`).
-
-### `sbot.metafeeds.find(metafeed, visit, cb)`
+### 🌻 `sbot.metafeeds.find(metafeed, visit, cb)`
 
 _Looks for the first subfeed of `metafeed` that satisfies the condition in
 `visit`._
@@ -176,7 +172,25 @@ possible error, and the 2nd argument is the found feed (which can be either the
 root meta feed `{ seed, keys }` or a sub feed
 `{ feedpurpose, subfeed, keys, metadata }`).
 
-### `sbot.metafeeds.create(metafeed, details, cb)`
+### 🌻 `sbot.metafeeds.filter(metafeed, visit, cb)`
+
+_Looks for all subfeeds of `metafeed` that satisfy the condition in `visit`._
+
+`metafeed` can be either `null` or a meta feed object `{ seed, keys }` (as
+returned by `create()`). If it's null, then the result will be an array
+containing one item, the root meta feed, or zero items if the root meta feed
+does not exist.
+
+`visit` can be either `null` or a function of the shape
+`({feedpurpose,subfeed,keys}) => boolean`. If it's null, then all subfeeds under
+`metafeed` are returned.
+
+The response is delivered to the callback `cb`, where the 1st argument is the
+possible error, and the 2nd argument is an array containing the found feeds
+(which can be either the root meta feed `{ seed, keys }` or a sub feed
+`{ feedpurpose, subfeed, keys, metadata }`).
+
+### 🌻 `sbot.metafeeds.create(metafeed, details, cb)`
 
 _Creates a new subfeed of `metafeed` matching the properties described in
 `details`._
@@ -198,7 +212,7 @@ possible error, and the 2nd argument is the created feed (which can be either
 the root meta feed `{ seed, keys }` or a sub feed
 `{ feedpurpose, subfeed, keys }`).
 
-### `sbot.metafeeds.findOrCreate(metafeed, visit, details, cb)`
+### 🌻 `sbot.metafeeds.findOrCreate(metafeed, visit, details, cb)`
 
 _Looks for the first subfeed of `metafeed` that satisfies the condition in
 `visit`, or creates it matching the properties in `details`._
@@ -225,7 +239,7 @@ possible error, and the 2nd argument is the created feed (which can be either
 the root meta feed `{ seed, keys }` or a sub feed
 `{ feedpurpose, subfeed, keys, metadata }`).
 
-### `sbot.metafeeds.filterTombstoned(metafeed, visit, cb)`
+### 🌻 `sbot.metafeeds.filterTombstoned(metafeed, visit, cb)`
 
 _Looks for all tombstoned subfeeds of `metafeed` that satisfy the condition in
 `visit`._
@@ -241,7 +255,7 @@ The response is delivered to the callback `cb`, where the 1st argument is the
 possible error, and the 2nd argument is an array containing the found tombstoned
 feeds.
 
-### `sbot.metafeeds.find(metafeed, visit, cb)`
+### 🌻 `sbot.metafeeds.find(metafeed, visit, cb)`
 
 _Looks for the first tombstoned subfeed of `metafeed` that satisfies the
 condition in `visit`._
@@ -264,21 +278,30 @@ Exposed via the internal API.
 
 _Validate a single meta feed message._
 
-Extracts the `contentSection` from the given `msg` object and calls `validateSingle()` to perform validation checks.
+Extracts the `contentSection` from the given `msg` object and calls
+`validateSingle()` to perform validation checks.
 
-If provided, the `hmacKey` is also given as input to the `validateSingle()` function call. `hmacKey` may be `null` or a valid HMAC key supplied as a `Buffer` or `string`.
+If provided, the `hmacKey` is also given as input to the `validateSingle()`
+function call. `hmacKey` may be `null` or a valid HMAC key supplied as a
+`Buffer` or `string`.
 
-The response is a boolean: `true` if validation is successful, `false` if validation fails in any way. Note that this function does not return the underlying cause of the validation failure.
+The response is a boolean: `true` if validation is successful, `false` if
+validation fails in any way. Note that this function does not return the
+underlying cause of the validation failure.
 
 ### `validateSingle(contentSection, hmacKey)`
 
-_Validate a single meta feed message `contentSection` according to the criteria defined in the [specification](https://github.com/ssb-ngi-pointer/ssb-meta-feed-spec#usage-of-bendy-butt-feed-format)._
+_Validate a single meta feed message `contentSection` according to the criteria
+defined in the [specification](https://github.com/ssb-ngi-pointer/ssb-meta-feed-spec#usage-of-bendy-butt-feed-format)._
 
-`contentSection` must be an array of `content` and `contentSignature`. If a `string` is provided (representing an encrypted message, for instance) an error will be returned; an encrypted `contentSection` cannot be validated.
+`contentSection` must be an array of `content` and `contentSignature`. If a
+`string` is provided (representing an encrypted message, for instance) an error
+will be returned; an encrypted `contentSection` cannot be validated.
 
 `hmacKey` may be `null` or a valid HMAC key supplied as a `Buffer` or `string`.
 
-The response will be `undefined` (for successful validation) or an `Error` object with a `message` describing the error.
+The response will be `undefined` (for successful validation) or an `Error`
+object with a `message` describing the error.
 
 ## License
 

--- a/api.js
+++ b/api.js
@@ -70,6 +70,10 @@ exports.init = function (sbot, config) {
     }
   }
 
+  function findById(feedId, cb) {
+    sbot.metafeeds.query.getMetadata(feedId, cb)
+  }
+
   function filterTombstoned(metafeed, maybeVisit, cb) {
     if (!metafeed || typeof metafeed === 'function') {
       cb(new Error('filterTombstoned() requires a valid metafeed argument'))
@@ -228,6 +232,7 @@ exports.init = function (sbot, config) {
   return {
     filter,
     find,
+    findById,
     create,
     findOrCreate,
     filterTombstoned,

--- a/test/api.js
+++ b/test/api.js
@@ -183,7 +183,20 @@ tape('findOrCreate() a subfeed under a sub meta feed', (t) => {
             t.equals(f.feedpurpose, 'index', 'it is the index subfeed')
             t.equals(f.metadata.query, 'foo', 'query is okay')
             t.true(f.subfeed.endsWith('.ed25519'), 'is a classic feed')
-            t.end()
+
+            sbot.metafeeds.findById(f.subfeed, (err, details) => {
+              t.error(err, 'no err')
+              t.deepEquals(Object.keys(details), [
+                'feedformat',
+                'feedpurpose',
+                'metafeed',
+                'metadata',
+              ])
+              t.equals(details.feedpurpose, 'index')
+              t.equals(details.metafeed, indexesMF.keys.id)
+              t.equals(details.feedformat, 'ed25519')
+              t.end()
+            })
           }
         )
       }

--- a/test/query.js
+++ b/test/query.js
@@ -91,8 +91,8 @@ test('metafeed with multiple feeds', (t) => {
 })
 
 test('index metafeed', (t) => {
-  sbot.metafeeds.query.getMetadata(indexKey.id, (err, content) => {
-    t.equal(JSON.parse(content.query).op, 'and', 'has query')
+  sbot.metafeeds.query.getMetadata(indexKey.id, (err, details) => {
+    t.equal(JSON.parse(details.metadata.query).op, 'and', 'has query')
     t.end()
   })
 })


### PR DESCRIPTION
## Context

In the new multi-format ssb-ebt we need to be able to get any feedID and infer what is it: is it a classic `main` feed? Is it a `classic` index feed? Is it a bendy butt? (The first 2 questions are the most important) It's not enough to just look at the feedId and infer the `feedformat`, we also need to know the `feedpurpose`. In ssb-replication-scheduler we will also need something like this.

## Solution

New API `findById()`. Turns out it was already implemented as `getMetadata`, I just did further tweaking in its internals, to:

- If the feedId given to `findById()` has been tombstoned, return `null`
- Infer the `feedformat` from the `feedId`
- Remove msg.value.content stuff such as `type` and `nonce` etc
- Bundle unknown fields in `msg.value.content` under `metadata` object, like it is during subfeed creation