### PR TITLE
add findByIdSync API

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ with the following shape:
 { feedpurpose, feedformat, metafeed, metafeed }
 ```
 
+### 🌷 `sbot.metafeeds.findByIdSync(feedId)`
+
+Similar to `findById`, but returns synchronously. :warning: Note, in order to
+use this API, you **must** call `sbot.metafeeds.loadState(cb)` first, and wait
+for `cb` to be called.
+
 ### 🌻 `sbot.metafeeds.find(metafeed, visit, cb)`
 
 _Looks for the first subfeed of `metafeed` that satisfies the condition in

--- a/api.js
+++ b/api.js
@@ -71,7 +71,15 @@ exports.init = function (sbot, config) {
   }
 
   function findById(feedId, cb) {
-    sbot.metafeeds.query.getMetadata(feedId, cb)
+    sbot.metafeeds.lookup.findById(feedId, cb)
+  }
+
+  function loadState(cb) {
+    sbot.metafeeds.lookup.loadState(cb)
+  }
+
+  function findByIdSync(feedId) {
+    return sbot.metafeeds.lookup.findByIdSync(feedId)
   }
 
   function filterTombstoned(metafeed, maybeVisit, cb) {
@@ -233,6 +241,8 @@ exports.init = function (sbot, config) {
     filter,
     find,
     findById,
+    findByIdSync,
+    loadState,
     create,
     findOrCreate,
     filterTombstoned,

--- a/feeds-lookup.js
+++ b/feeds-lookup.js
@@ -110,12 +110,10 @@ exports.init = function (sbot, config) {
           stateLoaded = true
           cb() // signal that we're ready to findByIdSync
 
-          // sbot.close.hook(function (fn, args) {
-          //   console.log('will abort liveDrainer')
-          //   if (liveDrainer) liveDrainer.abort()
-          //   console.log('did abort liveDrainer')
-          //   fn.apply(this, args)
-          // })
+          sbot.close.hook(function (fn, args) {
+            if (liveDrainer) liveDrainer.abort()
+            fn.apply(this, args)
+          })
 
           pull(
             sbot.db.query(
@@ -124,7 +122,7 @@ exports.init = function (sbot, config) {
               toPullStream()
             ),
             pull.filter((msg) => msg.value.content.subfeed),
-            pull.drain(updateLookup)
+            (liveDrainer = pull.drain(updateLookup))
           )
         })
       )

--- a/feeds-lookup.js
+++ b/feeds-lookup.js
@@ -1,0 +1,172 @@
+const { seekKey } = require('bipf')
+const pull = require('pull-stream')
+const SSBURI = require('ssb-uri2')
+const {
+  where,
+  and,
+  isPublic,
+  live,
+  equal,
+  authorIsBendyButtV1,
+  toPullStream,
+  toCallback,
+} = require('ssb-db2/operators')
+const validate = require('./validate')
+
+const SUBFEED_PREFIX_OFFSET = Math.max(
+  '@'.length,
+  'ssb:feed/bendybutt-v1/'.length,
+  'ssb:feed/gabbygrove-v1/'.length
+)
+
+const B_VALUE = Buffer.from('value')
+const B_CONTENT = Buffer.from('content')
+const B_SUBFEED = Buffer.from('subfeed')
+
+function seekSubfeed(buffer) {
+  let p = 0 // note you pass in p!
+  p = seekKey(buffer, p, B_VALUE)
+  if (p < 0) return
+  p = seekKey(buffer, p, B_CONTENT)
+  if (p < 0) return
+  return seekKey(buffer, p, B_SUBFEED)
+}
+
+function subfeed(feedId) {
+  return equal(seekSubfeed, feedId, {
+    prefix: 32,
+    prefixOffset: SUBFEED_PREFIX_OFFSET,
+    indexType: 'value_content_subfeed',
+  })
+}
+
+exports.init = function (sbot, config) {
+  let stateLoaded = false
+  let liveDrainer = null
+  const lookup = new Map()
+
+  function assertFeedId(feedId) {
+    if (!feedId) {
+      return cb(new Error('feedId should be provided'))
+    }
+    if (typeof feedId !== 'string') {
+      return cb(new Error('feedId should be a string, but got ' + feedId))
+    }
+  }
+
+  function detectFeedFormat(feedId) {
+    if (feedId.startsWith('@')) {
+      return 'ed25519'
+    } else if (SSBURI.isBendyButtV1FeedSSBURI(feedId)) {
+      return 'bendybutt-v1'
+    } else {
+      throw new Error('Invalid feed format: ' + feedId)
+    }
+  }
+
+  function msgToDetails(msg) {
+    const content = msg.value.content
+    const details = {}
+    details.feedformat = detectFeedFormat(content.subfeed)
+    details.feedpurpose = content.feedpurpose
+    details.metafeed = content.metafeed
+    const metadata = {}
+    const NOT_METADATA = [
+      'metafeed',
+      'feedpurpose',
+      'type',
+      'tangles',
+      'subfeed',
+      'nonce',
+    ]
+    const keys = Object.keys(content).filter((k) => !NOT_METADATA.includes(k))
+    for (const key of keys) {
+      metadata[key] = content[key]
+    }
+    details.metadata = metadata
+    return details
+  }
+
+  function updateLookup(msg) {
+    const content = msg.value.content
+    if (content.type.startsWith('metafeed/add/')) {
+      lookup.set(content.subfeed, msgToDetails(msg))
+    } else if (content.type === 'metafeed/tombstone') {
+      lookup.delete(content.subfeed)
+    }
+  }
+
+  return {
+    loadState(cb) {
+      pull(
+        sbot.db.query(
+          where(and(authorIsBendyButtV1(), isPublic())),
+          toPullStream()
+        ),
+        pull.filter((msg) => msg.value.content.subfeed),
+        pull.drain(updateLookup, (err) => {
+          if (err) return cb(err)
+
+          stateLoaded = true
+          cb() // signal that we're ready to findByIdSync
+
+          // sbot.close.hook(function (fn, args) {
+          //   console.log('will abort liveDrainer')
+          //   if (liveDrainer) liveDrainer.abort()
+          //   console.log('did abort liveDrainer')
+          //   fn.apply(this, args)
+          // })
+
+          pull(
+            sbot.db.query(
+              where(and(authorIsBendyButtV1(), isPublic())),
+              live(),
+              toPullStream()
+            ),
+            pull.filter((msg) => msg.value.content.subfeed),
+            pull.drain(updateLookup)
+          )
+        })
+      )
+    },
+
+    findByIdSync(feedId) {
+      if (!stateLoaded) {
+        throw new Error('Please call loadState() before using findByIdSync()')
+      }
+      assertFeedId(feedId)
+
+      return lookup.get(feedId)
+    },
+
+    findById(feedId, cb) {
+      assertFeedId(feedId)
+      try {
+        detectFeedFormat(feedId)
+      } catch (err) {
+        return cb(err)
+      }
+
+      sbot.db.query(
+        where(subfeed(feedId)),
+        toCallback((err, msgs) => {
+          if (err) return cb(err)
+
+          msgs = msgs.filter((msg) => validate.isValid(msg))
+          if (msgs.find((m) => m.value.content.type === 'metafeed/tombstone')) {
+            return cb(null, null)
+          }
+          msgs = msgs.filter((m) =>
+            m.value.content.type.startsWith('metafeed/add/')
+          )
+          if (msgs.length === 0) {
+            return cb(null, null)
+          }
+
+          const details = msgToDetails(msgs[0])
+          cb(null, details)
+        })
+      )
+    },
+  }
+}

--- a/feeds-lookup.js
+++ b/feeds-lookup.js
@@ -105,7 +105,7 @@ exports.init = function (sbot, config) {
         where(and(authorIsBendyButtV1(), isPublic())),
         toPullStream()
       ),
-      pull.filter((msg) => msg.value.content.subfeed),
+      pull.filter((msg) => validate.isValid(msg)),
       pull.drain(updateLookup, (err) => {
         if (err) return cb(err)
 
@@ -123,7 +123,7 @@ exports.init = function (sbot, config) {
             live(),
             toPullStream()
           ),
-          pull.filter((msg) => msg.value.content.subfeed),
+          pull.filter((msg) => validate.isValid(msg)),
           (liveDrainer = pull.drain(updateLookup))
         )
       })

--- a/index.js
+++ b/index.js
@@ -3,12 +3,14 @@ const Messages = require('./messages')
 const Query = require('./query')
 const API = require('./api')
 const Validate = require('./validate')
+const FeedsLookup = require('./feeds-lookup')
 
 exports.name = 'metafeeds'
 
 exports.init = function (sbot, config) {
   const messages = Messages.init(sbot, config)
   const query = Query.init(sbot, config)
+  const lookup = FeedsLookup.init(sbot, config)
   const api = API.init(sbot, config)
 
   return {
@@ -18,6 +20,7 @@ exports.init = function (sbot, config) {
     // Internals
     keys: Keys,
     messages,
+    lookup,
     query,
     validate: Validate,
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pull-stream": "^3.6.14",
     "ssb-bendy-butt": "~0.12.3",
     "ssb-bfe": "^3.1.1",
-    "ssb-db2": "^2.5.0",
+    "ssb-db2": "^2.5.1",
     "ssb-keys": "^8.2.0",
     "ssb-ref": "^2.16.0",
     "ssb-uri2": "^1.5.2"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "debug": "^4.3.0",
     "futoin-hkdf": "^1.4.2",
     "is-canonical-base64": "^1.1.1",
+    "p-defer": "^3.0.0",
     "promisify-tuple": "^1.2.0",
     "pull-stream": "^3.6.14",
     "ssb-bendy-butt": "~0.12.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pull-stream": "^3.6.14",
     "ssb-bendy-butt": "~0.12.3",
     "ssb-bfe": "^3.1.1",
-    "ssb-db2": "^2.4.0",
+    "ssb-db2": "^2.5.0",
     "ssb-keys": "^8.2.0",
     "ssb-ref": "^2.16.0",
     "ssb-uri2": "^1.5.2"

--- a/test/api.js
+++ b/test/api.js
@@ -195,7 +195,22 @@ tape('findOrCreate() a subfeed under a sub meta feed', (t) => {
               t.equals(details.feedpurpose, 'index')
               t.equals(details.metafeed, indexesMF.keys.id)
               t.equals(details.feedformat, 'ed25519')
-              t.end()
+
+              t.throws(
+                () => {
+                  sbot.metafeeds.findByIdSync(f.subfeed)
+                },
+                /Please call loadState/,
+                'findByIdSync throws'
+              )
+
+              sbot.metafeeds.loadState((err) => {
+                t.error(err, 'no err')
+                const details2 = sbot.metafeeds.findByIdSync(f.subfeed)
+                t.deepEquals(details2, details, 'findByIdSync same as findById')
+
+                t.end()
+              })
             })
           }
         )

--- a/test/query.js
+++ b/test/query.js
@@ -90,13 +90,6 @@ test('metafeed with multiple feeds', (t) => {
   })
 })
 
-test('index metafeed', (t) => {
-  sbot.metafeeds.query.getMetadata(indexKey.id, (err, details) => {
-    t.equal(JSON.parse(details.metadata.query).op, 'and', 'has query')
-    t.end()
-  })
-})
-
 test('metafeed with tombstones', (t) => {
   const reason = 'Feed no longer used'
 


### PR DESCRIPTION
- [x] Pending on https://github.com/ssb-ngi-pointer/ssb-db2/pull/260

Adds `findByIdSync`, similar to `findById`, but synchronous (see e.g. similar to `fs.readFile` and `fs.readFileSync`). The synchronous variant requires calling `loadState(cb)` before usage, otherwise it throws an error.

I also refactored/moved stuff from query.js to feeds-lookup.js.