### PR TITLE
new API ensureLoaded()

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ Similar to `findById`, but returns synchronously. :warning: Note, in order to
 use this API, you **must** call `sbot.metafeeds.loadState(cb)` first, and wait
 for `cb` to be called.
 
+You can also call `sbot.metafeeds.ensureLoaded(feedId, cb)` on an individual
+basis to make sure that `findByIdSync` will operate at the correct time when the
+`feedId`'s metadata has been processed in the local database.
+
 ### 🌻 `sbot.metafeeds.find(metafeed, visit, cb)`
 
 _Looks for the first subfeed of `metafeed` that satisfies the condition in

--- a/api.js
+++ b/api.js
@@ -78,6 +78,10 @@ exports.init = function (sbot, config) {
     sbot.metafeeds.lookup.loadState(cb)
   }
 
+  function ensureLoaded(feedId, cb) {
+    sbot.metafeeds.lookup.ensureLoaded(feedId, cb)
+  }
+
   function findByIdSync(feedId) {
     return sbot.metafeeds.lookup.findByIdSync(feedId)
   }
@@ -243,6 +247,7 @@ exports.init = function (sbot, config) {
     findById,
     findByIdSync,
     loadState,
+    ensureLoaded,
     create,
     findOrCreate,
     filterTombstoned,

--- a/test/api.js
+++ b/test/api.js
@@ -243,22 +243,29 @@ test('restart sbot', (t) => {
         path: dir,
       })
 
-    sbot.metafeeds.findOrCreate(null, null, {}, (err, mf) => {
-      t.error(err, 'no err')
-      t.ok(Buffer.isBuffer(mf.seed), 'has seed')
-      t.ok(mf.keys.id.startsWith('ssb:feed/bendybutt-v1/'), 'has key')
+    sbot.metafeeds.ensureLoaded(testIndexFeed, () => {
+      const details = sbot.metafeeds.findByIdSync(testIndexFeed)
+      t.equals(details.feedpurpose, 'index')
+      t.equals(details.metafeed, testIndexesMF.keys.id)
+      t.equals(details.feedformat, 'ed25519')
 
-      sbot.metafeeds.filter(mf, null, (err, filtered) => {
+      sbot.metafeeds.findOrCreate(null, null, {}, (err, mf) => {
         t.error(err, 'no err')
-        t.equal(filtered.length, 3, 'has 3 subfeeds')
-        t.equal(filtered[0].feedpurpose, 'main', 'main')
-        t.equal(filtered[1].feedpurpose, 'chess', 'chess')
-        t.equal(filtered[2].feedpurpose, 'indexes', 'indexes')
+        t.ok(Buffer.isBuffer(mf.seed), 'has seed')
+        t.ok(mf.keys.id.startsWith('ssb:feed/bendybutt-v1/'), 'has key')
 
-        sbot.metafeeds.filterTombstoned(mf, null, (err, tombstoned) => {
+        sbot.metafeeds.filter(mf, null, (err, filtered) => {
           t.error(err, 'no err')
-          t.equal(tombstoned.length, 0, 'has 0 tombstoned feeds')
-          sbot.close(true, t.end)
+          t.equal(filtered.length, 3, 'has 3 subfeeds')
+          t.equal(filtered[0].feedpurpose, 'main', 'main')
+          t.equal(filtered[1].feedpurpose, 'chess', 'chess')
+          t.equal(filtered[2].feedpurpose, 'indexes', 'indexes')
+
+          sbot.metafeeds.filterTombstoned(mf, null, (err, tombstoned) => {
+            t.error(err, 'no err')
+            t.equal(tombstoned.length, 0, 'has 0 tombstoned feeds')
+            sbot.close(true, t.end)
+          })
         })
       })
     })


### PR DESCRIPTION
## Context

ssb-meta-feeds `findByIdSync` is used in the new ssb-ebt https://github.com/ssbc/ssb-ebt/pull/52 which in turn is used in https://github.com/ssb-ngi-pointer/ssb-replication-scheduler/pull/5 . 

## Problem

We bumped into a race condition where there are two pull.drains on meta feed messages: **(A)** one in ssb-meta-feeds `feeds-lookup.js` (to keep track of the "details" object associated which each (foreign or local) subfeed ID) and **(B)** another one in `ssb-replication-scheduler` to trigger the replication of a subfeed. We realized that the processing in **(A)** for a specific subfeed ID  **must** happen before the respective processing in **(B)** because information calculated in **(A)** will be needed by ssb-ebt once **(B)** calls into ssb-ebt APIs.

## Solution

New API `ensureLoaded(feedId, cb)` similar to `loadState(cb)`, but for a specific `feedId`.

While `loadState(cb)` just kicks off the pull.drain for all possible meta feed msgs, `ensureLoaded()` will wait until the specific `feedId` has been processed by the **next** `updateLookup()`.

This should be one of the pieces of the puzzle to solve the Problem described above, we will also need a few changes in ssb-ebt to fully solve it.