### PR TITLE
rename one "ed25519" to "classic"

### DIFF
--- a/feeds-lookup.js
+++ b/feeds-lookup.js
@@ -74,7 +74,7 @@ exports.init = function (sbot, config) {
 
   function detectFeedFormat(feedId) {
     if (feedId.startsWith('@')) {
-      return 'ed25519'
+      return 'classic'
     } else if (SSBURI.isBendyButtV1FeedSSBURI(feedId)) {
       return 'bendybutt-v1'
     } else {

--- a/test/api.js
+++ b/test/api.js
@@ -212,7 +212,7 @@ test('findById and findByIdSync', (t) => {
       ])
       t.equals(details.feedpurpose, 'index')
       t.equals(details.metafeed, testIndexesMF.keys.id)
-      t.equals(details.feedformat, 'ed25519')
+      t.equals(details.feedformat, 'classic')
 
       t.throws(
         () => {
@@ -247,7 +247,7 @@ test('restart sbot', (t) => {
       const details = sbot.metafeeds.findByIdSync(testIndexFeed)
       t.equals(details.feedpurpose, 'index')
       t.equals(details.metafeed, testIndexesMF.keys.id)
-      t.equals(details.feedformat, 'ed25519')
+      t.equals(details.feedformat, 'classic')
 
       sbot.metafeeds.findOrCreate(null, null, {}, (err, mf) => {
         t.error(err, 'no err')


### PR DESCRIPTION
This one slipped through. For consistency, we should use `classic` everywhere in this module.