### PR TITLE
cache the root meta feed in memory

### DIFF
--- a/api.js
+++ b/api.js
@@ -177,11 +177,17 @@ exports.init = function (sbot, config) {
   // lock to solve concurrent getOrCreateRootMetafeed
   const rootMetaFeedLock = {
     _cbs: [],
+    _cachedMF: null,
     acquire(cb) {
+      if (this._cachedMF) {
+        cb(null, this._cachedMF)
+        return false
+      }
       this._cbs.push(cb)
       return this._cbs.length === 1
     },
     release(err, mf) {
+      this._cachedMF = mf
       const cbs = this._cbs
       this._cbs = []
       for (const cb of cbs) cb(err, mf)


### PR DESCRIPTION
Here's something nice I bumped into.

If the root meta feed has already been fetched (from disk) or created, then we can just store it in memory, in the lock. This should be an optimization because it prevents subsequent calls to look it up from the disk.

(Actually, now that I'm typing this, I'm not sure if this is worthwhile optimization. ssb-db2 and jitdb seem to have quite a good amount of caching already. Feel free to say no to this PR)