### PR TITLE
hard deprecate find() and filter()

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ This is strictly concerned with meta feeds and sub feeds that **you own**, not
 with those that belong to other peers.
 
 `metafeed` can be either `null` or a meta feed object `{ seed, keys }` (as
-returned by `create()`). If it's null, then the root meta feed will be created,
+returned by `getRoot()`). If it's null, then the root meta feed will be created,
 if and only if it does not already exist. If it's null and the root meta feed
 exists, the root meta feed will be returned via the `cb`. Alternatively, you can
 call this API with just the callback: `sbot.metafeeds.findOrCreate(cb)`.
@@ -198,6 +198,24 @@ The response is delivered to the callback `cb`, where the 1st argument is the
 possible error, and the 2nd argument is the created feed (which can be either
 the root meta feed `{ seed, keys }` or a sub feed
 `{ feedpurpose, subfeed, keys, metadata }`).
+
+### `sbot.metafeeds.findAndTombstone(metafeed, visit, reason, cb)`
+
+_Looks for the first subfeed of `metafeed` that satisfies the condition in
+`visit` and, if found, tombstones it with the string `reason`.
+
+This is strictly concerned with meta feeds and sub feeds that **you own**, not
+with those that belong to other peers.
+
+`metafeed` must be a meta feed object `{ seed, keys }` (as returned by
+`getRoot()`).
+
+`visit` must be a function of the shape `({feedpurpose, subfeed, metadata, keys}) => boolean`.
+
+`reason` must be a string to describe why the found feed is being tombstoned.
+
+The callback is called with `true` on the 2nd argument if tombstoning suceeded,
+or called with an error object on the 1st argument if it failed.
 
 ### `sbot.metafeeds.getRoot(cb)`
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ The `opts` argument can have the following properties:
   `loadState`) trees. (Default: `false`)
 - `opts.live` _Boolean_ - whether or not to include subsequent meta feed trees
   during the execution of your program. (Default: `true`)
+- `opts.tombstoned` _Boolean_ - if `false`, no tombstoned branches are included
+  in the results; if `true`, only tombstoned branches are included. (Default:
+  `false`)
 
 ### `sbot.metafeeds.findOrCreate(metafeed, visit, details, cb)`
 

--- a/api.js
+++ b/api.js
@@ -5,31 +5,11 @@ const validate = require('./validate')
 const alwaysTrue = () => true
 
 exports.init = function (sbot, config) {
-  function filterRootMetafeed(visit, cb) {
-    sbot.metafeeds.query.getSeed((err, seed) => {
-      if (err) return cb(err)
-      if (!seed) return cb(null, [])
-      const metafeed = {
-        seed,
-        keys: sbot.metafeeds.keys.deriveRootMetaFeedKeyFromSeed(seed),
-      }
-
-      if (visit(metafeed)) {
-        cb(null, [metafeed])
-      } else {
-        cb(null, [])
-      }
-    })
-  }
-
-  function filter(metafeed, maybeVisit, maybeCB) {
-    const visit = maybeVisit || alwaysTrue
+  function filter(metafeed, visit, maybeCB) {
     if (!metafeed) {
-      const cb = maybeCB
-      filterRootMetafeed(visit, cb)
+      cb(new Error('expected metafeed argument'))
     } else if (typeof metafeed === 'function') {
-      const cb = metafeed
-      filterRootMetafeed(visit, cb)
+      cb(new Error('expected metafeed argument and visit argument'))
     } else {
       const cb = maybeCB
       sbot.metafeeds.query.hydrate(
@@ -45,20 +25,11 @@ exports.init = function (sbot, config) {
     }
   }
 
-  function find(metafeed, maybeVisit, maybeCB) {
-    const visit = maybeVisit || alwaysTrue
+  function find(metafeed, visit, maybeCB) {
     if (!metafeed) {
-      const cb = maybeCB
-      filterRootMetafeed(visit, (err, metafeeds) => {
-        if (err) return cb(err)
-        cb(null, metafeeds[0])
-      })
+      cb(new Error('expected metafeed argument'))
     } else if (typeof metafeed === 'function') {
-      const cb = metafeed
-      filterRootMetafeed(visit, (err, metafeeds) => {
-        if (err) return cb(err)
-        cb(null, metafeeds[0])
-      })
+      cb(new Error('expected metafeed argument and visit argument'))
     } else {
       const cb = maybeCB
       filter(metafeed, visit, (err, feeds) => {
@@ -88,37 +59,6 @@ exports.init = function (sbot, config) {
 
   function branchStream(opts) {
     return sbot.metafeeds.lookup.branchStream(opts)
-  }
-
-  function filterTombstoned(metafeed, maybeVisit, cb) {
-    if (!metafeed || typeof metafeed === 'function') {
-      cb(new Error('filterTombstoned() requires a valid metafeed argument'))
-    } else {
-      const visit = maybeVisit || alwaysTrue
-      sbot.metafeeds.query.hydrate(
-        metafeed.keys.id,
-        metafeed.seed,
-        (err, hydrated) => {
-          if (err) return cb(err)
-          if (visit === alwaysTrue) return cb(null, hydrated.tombstoned)
-          const filtered = hydrated.tombstoned.filter((feed) => visit(feed))
-          cb(null, filtered)
-        }
-      )
-    }
-  }
-
-  function findTombstoned(metafeed, maybeVisit, cb) {
-    if (!metafeed || typeof metafeed === 'function') {
-      cb(new Error('findTombstoned() requires a valid metafeed argument'))
-    } else {
-      filterTombstoned(metafeed, maybeVisit, (err, tombstoned) => {
-        if (err) return cb(err)
-        if (tombstoned.length === 0) return cb(null, null)
-        const found = tombstoned[0]
-        cb(null, found)
-      })
-    }
   }
 
   function create(metafeed, details, maybeCB) {
@@ -166,7 +106,8 @@ exports.init = function (sbot, config) {
       getOrCreateRootMetafeed(cb)
     } else {
       const cb = maybeCB
-      find(metafeed, maybeVisit, (err, found) => {
+      const visit = maybeVisit || alwaysTrue
+      find(metafeed, visit, (err, found) => {
         if (err) return cb(err)
         if (found) return cb(null, found)
         create(metafeed, details, cb)
@@ -192,6 +133,18 @@ exports.init = function (sbot, config) {
       this._cbs = []
       for (const cb of cbs) cb(err, mf)
     },
+  }
+
+  function getRoot(cb) {
+    sbot.metafeeds.query.getSeed((err, seed) => {
+      if (err) return cb(err)
+      if (!seed) return cb(null, null)
+      const metafeed = {
+        seed,
+        keys: sbot.metafeeds.keys.deriveRootMetaFeedKeyFromSeed(seed),
+      }
+      cb(null, metafeed)
+    })
   }
 
   async function getOrCreateRootMetafeed(cb) {
@@ -252,16 +205,12 @@ exports.init = function (sbot, config) {
   }
 
   return {
-    filter,
-    find,
+    getRoot,
+    findOrCreate,
     findById,
     findByIdSync,
     loadState,
     ensureLoaded,
-    create,
-    findOrCreate,
     branchStream,
-    filterTombstoned,
-    findTombstoned,
   }
 }

--- a/query.js
+++ b/query.js
@@ -110,6 +110,8 @@ exports.init = function (sbot, config) {
             feedformat
           )
       return {
+        metafeed: msg.value.author,
+        feedformat,
         feedpurpose,
         subfeed,
         keys,

--- a/test/validate.js
+++ b/test/validate.js
@@ -30,12 +30,10 @@ function encodedDataToContentSection(data) {
   return contentSection
 }
 
-tape('validation works', function (t) {
+tape('basic validation works', function (t) {
   const contentSection1 = entryToContentSection(vec.Entries[0])
   const contentSection2 = entryToContentSection(vec.Entries[1])
   const contentSection3 = entryToContentSection(vec.Entries[2])
-
-  t.pass('[ basic tests ]')
 
   const msg1ValidationResult = mf.validateSingle(contentSection1, null)
   t.deepEqual(
@@ -138,9 +136,10 @@ tape('validation works', function (t) {
   // revert nonce change
   contentSection2[0].nonce = 'QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI='
 
-  /* vector tests for messages with invalid content */
-  t.pass('[ bad message vector tests ]')
+  t.end()
+})
 
+tape('bad message vector tests', function (t) {
   // "1.1: bad type value"
   // convert json vector entry to testable contentSection
   const badMsg1 = Buffer.from(badVec.Cases[0].Entries[0].EncodedData, 'hex')


### PR DESCRIPTION
So, I began by thinking how to make `find(metafeed, visit, cb)` be usable for foreign peers. It wasn't so obvious, because `find` could be used in so many ways:

- `find(null, null, cb)` to get your own root mf
- `find(myRoot, visit, cb)` to get my own subfeeds
- `find(somethingConfusing, visit, cb)` to get foreign subfeeds

In the third case, what if you just wanted to pass a `visit` function and you don't care about the 1st arg? That seems ambiguous because if the 1st arg is null, it means you want to find something that you own. And actually `find(null, null, cb)` is also ambiguous because it looks like you want to get *any* subfeed.

----

So I side stepped this whole headache when I realized that `branchStream` can already be used as an API to find any subfeeds. You just need to use standard pull-stream `filter` and `take`.

So this PR makes this change to the API:

```diff
-filter
-find
-create
 findOrCreate
+getRoot
 findById
 findByIdSync
 loadState
 ensureLoaded
 branchStream
-filterTombstoned
-findTombstoned
```

I intend to update `branchStream` so that it gets `opts.tombstoned` as a boolean, and this should cover our needs for `filterTombstoned` and `findTombstoned`. But I'll do that in another PR (anyway, we need a new API to create a tombstone).

The reason why I added `getRoot` is that there is one use case in ssb-replication-scheduler where we just want to check if we have a root meta feed, but not create it.