### PR TITLE
branchStream supports opts.tombstoned=null

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ The `opts` argument can have the following properties:
 - `opts.live` _Boolean_ - whether or not to include subsequent meta feed trees
   during the execution of your program. (Default: `true`)
 - `opts.tombstoned` _Boolean_ - if `false`, no tombstoned branches are included
-  in the results; if `true`, only tombstoned branches are included. (Default:
-  `false`)
+  in the results; if `true`, only tombstoned branches are included; if `null`,
+  all branches are included regardless of tombstoning. (Default: `null`)
 
 ### `sbot.metafeeds.findOrCreate(metafeed, visit, details, cb)`
 

--- a/feeds-lookup.js
+++ b/feeds-lookup.js
@@ -273,7 +273,7 @@ exports.init = function (sbot, config) {
         live = true,
         old = false,
         root = null,
-        tombstoned = false,
+        tombstoned = null,
       } = opts || {}
 
       const filterRootFn = root
@@ -281,11 +281,13 @@ exports.init = function (sbot, config) {
         : () => true
 
       const filterTombstoneOrNot = (branch) => {
-        if (branch.length === 1) return !tombstoned && branch[0][1] === null
-        else {
-          return branch.every(
-            ([, details]) => !details || !!details.tombstoned === tombstoned
-          )
+        const [, leafDetails] = branch[branch.length - 1]
+        if (tombstoned === null) {
+          return true
+        } else if (tombstoned === false) {
+          return branch.every(([, details]) => !details || !details.tombstoned)
+        } else if (tombstoned === true) {
+          return leafDetails && !!leafDetails.tombstoned
         }
       }
 

--- a/test/api.js
+++ b/test/api.js
@@ -294,7 +294,20 @@ tape('findAndTombstone and tombstoning branchStream', (t) => {
               pull.collect((err, branches) => {
                 t.error(err, 'no err')
                 t.equal(branches.length, 4, '4 branches')
-                t.end()
+
+                pull(
+                  sbot.metafeeds.branchStream({
+                    tombstone: null,
+                    old: true,
+                    live: false,
+                  }),
+                  pull.collect((err, branches) => {
+                    t.error(err, 'no err')
+                    t.equal(branches.length, 5, '5 branches')
+
+                    t.end()
+                  })
+                )
               })
             )
           })


### PR DESCRIPTION
Currently, `branchStream` supports `opts.tombstoned` as a boolean. 

In ssb-replication-scheduler I need a way of looking up the *non-tombstoned* subfeeds of a *tombstoned* feed, because those subfeeds are to be considered implicitly tombstoned as well. The current `branchStream` doesn't let me do that.

This PR changes `opts.tombstoned` to allow `null`, which means I can look up subfeeds regardless of their tombstoning status.